### PR TITLE
Overhauled settings manager so users can modify settings in the /admi…

### DIFF
--- a/classes/Cache/Manager-next.php
+++ b/classes/Cache/Manager-next.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Cache Manager
+ * 
+ * The Cobalt Engine offers a filename-based approach to cached files. This class
+ * handles caches.
+ * 
+ * @author Gardiner Bryant <gardiner@heavyelement.io>
+ * @license https://github.com/heavyelementinc/cobalt-core/license
+ * @copyright 2021 Heavy Element, Inc.
+ */
+
+namespace Cache;
+
+use Exception;
+
+class Manager extends \Drivers\FileSystem {
+
+    private $cache_dir = __APP_ROOT__ . "/cache";
+
+    function __construct($filename) {
+        parent::__construct();
+        $this->reference = $filename;
+        $this->file_path = $this->cache_name($this->reference);
+        $this->exists = $this->cache_exists();
+        $this->last_modified = $this->modified();
+    }
+
+    /** Retrieve a file by it's common reference for example:
+     * "config/settings.json" 
+     * 
+     * That filename will be parsed and retrieved from the cache.
+     * 
+     * @param bool $load [true] false will return the pathname */
+    public function get($load = true) {
+        if ($load == false) return $this->file_path;
+        $path = $this->file_path;
+        if (!$this->exists) throw new \Exception("File `$this->reference` does not exist in cache");
+        if ($load === "json") return get_json($path);
+        if ($load) return file_get_contents($path);
+        return $this->reference;
+    }
+
+    /**
+     * Set a cache item
+     * 
+     * @param string|json-able $contents string
+     * @param bool $json [true] json_encode the contents
+     * @return mixed 
+     * @throws Exception 
+     */
+    public function set($contents, $json = true) {
+        $path = $this->file_path;
+        $info = pathinfo($path, PATHINFO_DIRNAME);
+        $mkdir = true;
+        if (!is_dir($info)) $mkdir = mkdir($info, 0777, true);
+        if (!$mkdir) throw new \Exception("Could not make the directory path for $this->reference");
+        if ($json) $contents = json_encode($contents);
+        if (@file_put_contents($path, $contents) === false) throw new \Exception("Could not write to $this->reference.");
+        return $path;
+    }
+
+    /**
+     * Checks if a cached version of the common reference exists.
+     * 
+     * @return bool 
+     */
+    public function cache_exists():bool {
+        if($this->findByFilename($this->file_path) !== null) return true;
+        return false;
+    }
+
+    function outdated($compare, $margin = 0) {
+        if (!$this->exists) return true;
+        $path = $this->file_path;
+        if (!file_exists($compare)) return false;
+        $resource_date = filemtime($compare);
+        $val = ($resource_date - $margin > $this->last_modified);
+        return $val;
+    }
+
+    function modified() {
+        if ($this->exists) return filemtime($this->file_path);
+        return 0;
+    }
+
+    private function cache_name($reference) {
+        $info = pathinfo($reference);
+        $version = __APP_SETTINGS__['version'] ?? "000";
+        $path = $this->cache_dir . "/$info[dirname]/$info[filename].$version.$info[extension]";
+        return $path;
+    }
+}

--- a/classes/Cobalt/Requests/Remote/API.php
+++ b/classes/Cobalt/Requests/Remote/API.php
@@ -146,7 +146,7 @@ abstract class API extends \Drivers\Database implements APICall {
         return $namespace . $exploded[count($exploded) - 1];
     }
 
-    final private function fetch(string $url, string $method) {
+    final private function fetch(string $url, string $method, mixed $body) {
         $this->authorizationToken();
 
         $data = [

--- a/classes/Cobalt/Requests/Remote/AmazonPA.php
+++ b/classes/Cobalt/Requests/Remote/AmazonPA.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Cobalt\Requests\Remote;
+
+class AmazonPA extends API {
+
+    public function refreshTokenCallback($result): string {
+        return "";
+    }
+
+    public function getPaginationToken(): array {
+        return [];
+    }
+
+    function getIfaceName():string {
+        return "\\Cobalt\\Requests\\Tokens\\AmazonPA";
+    }
+
+    function getChannelDataById($id) {
+        $this->addRequestParams([
+            'part' => [
+                // 'snippet',
+                // 'auditDetails',
+                'brandingSettings',
+                'contentDetails',
+                'contentOwnerDetails',
+                'id',
+                'localizations',
+                'snippet',
+                'statistics',
+                'status',
+                'topicDetails'
+            ],
+            'contentDetails' => 'statistics',
+            'id' => $id
+        ]);
+
+        return $this->get("https://www.googleapis.com/youtube/v3/channels");
+    }
+
+    static function getMetadata(): array {
+        return [
+            'icon' => "<ion-icon name='logo-amazon'></ion-icon>",
+            'name' => "Amazon Product Advertising"
+        ];
+    }
+}

--- a/classes/Cobalt/Requests/Tokens/AmazonPA.php
+++ b/classes/Cobalt/Requests/Tokens/AmazonPA.php
@@ -1,0 +1,52 @@
+<?php
+namespace Cobalt\Requests\Tokens;
+
+class AmazonPA extends TokenInterface {
+
+    public function getRefresh(): string {
+        return "";
+    }
+
+    public function setRefresh(): string {
+        return "";
+    }
+    
+    function getKey():string{
+        return $this->__token['key'] ?? "";
+    }
+    function getSecret():string{
+        return $this->__token['secret'] ?? "";
+    }
+    function getToken():string{
+        return $this->__token['token'] ?? "";
+    }
+    function getTokenType():string{
+        return "Authorization";
+    }
+    function getTokenPrefix():string{
+        return "Bearer";
+    }
+    function getTokenExpiration():\DateTime|null{
+        return null;
+    }
+    
+    /** Prepare for storage */
+    function setKey():string {
+        return "";
+    }
+    function setSecret():string {
+        return "";
+    }
+    function setToken():string {
+        return "";
+    }
+    function setTokenType():string {
+        return "";
+    }
+    function setTokenPrefix():string {
+        return "";
+    }
+    function setTokenExpiration():\DateTime|null {
+        return null;
+    }
+}

--- a/classes/Cobalt/Settings/Definitions/Fonts.php
+++ b/classes/Cobalt/Settings/Definitions/Fonts.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Cobalt\Settings\Definitions;
+
+use Cobalt\Settings\CobaltSetting;
+
+class Fonts extends CobaltSetting {
+    
+}

--- a/classes/Cobalt/Settings/Settings.php
+++ b/classes/Cobalt/Settings/Settings.php
@@ -28,6 +28,8 @@
 namespace Cobalt\Settings;
 
 use Exception;
+use Validation\Exceptions\ValidationFailed;
+use Validation\Exceptions\ValidationIssue;
 
 class Settings extends \Drivers\Database {
 
@@ -35,17 +37,18 @@ class Settings extends \Drivers\Database {
         __ENV_ROOT__ . "/config/default_settings.jsonc",
         __APP_ROOT__ . "/config/settings.jsonc",
         __APP_ROOT__ . "/ignored/config/settings.jsonc",
+        __APP_ROOT__ . "/config/settings.json",
+        __APP_ROOT__ . "/ignored/config/settings.json",
     ];
 
-    const __M_TIME_CANDIDATES__ = [
-        __APP_ROOT__ . "routes/web.php",
-        __APP_ROOT__ . "routes/apiv1.php",
-        __APP_ROOT__ . "routes/admin.php",
-        __APP_ROOT__ . "routes/webhook.php",
-        __ENV_ROOT__ . "routes/web.php",
-        __ENV_ROOT__ . "routes/apiv1.php",
-        __ENV_ROOT__ . "routes/admin.php",
-        __ENV_ROOT__ . "routes/webhook.php",
+    const __MANIFESTS__ = [
+        __ENV_ROOT__ . "/manifest.jsonc",
+        __APP_ROOT__ . "/manifest.jsonc",
+        __APP_ROOT__ . "/manifest.json",
+    ];
+
+    var $mtime_candidates = [
+        
     ];
 
     // const __SETTINGS__ = [
@@ -54,7 +57,7 @@ class Settings extends \Drivers\Database {
     //     __APP_ROOT__ . "/ignored/config/custom_settings.jsonc",
     // ];
 
-    function __construct($bootstrap = false) {
+    function __construct($bootstrap = true) {
         // Instance our parent class
         parent::__construct();
 
@@ -83,7 +86,7 @@ class Settings extends \Drivers\Database {
         // If there is no "Meta->max_m_time" property, do a bootstrap
         if(property_exists($this->__settings, "Meta") && !property_exists($this->__settings->Meta, "max_m_time")) return true;
         // If the cachedk max_m_time is less than the current max_m_time, do a bootstrap
-        if($this->Meta->max_m_time < $this->max_m_time) return true;
+        if($this->__settings->Meta->max_m_time < $this->max_m_time) return true;
         // Otherwise, we don't need to bootstrap.
         return false;
     }
@@ -95,6 +98,8 @@ class Settings extends \Drivers\Database {
 
         $this->__user_modified_settings = $this->fetchModifiedSettings();
 
+        $this->instances = [];
+
         // Process each setting and get the value
         $toCache = [];
         foreach($json as $name => $definition) {
@@ -102,20 +107,24 @@ class Settings extends \Drivers\Database {
             if(key_exists("definition",$definition)) {
                 $def = "\\Cobalt\\Settings\Definitions\\$definition[definition]";
                 try{
-                    $setting = new $def($name, $this->normalizeSetting($name, $definition), $this->__user_modified_settings, $this->__settings);
+                    $setting = new $def($name, $this->normalizeSetting($name, $definition), $this->__user_modified_settings, $this->__settings, $this, $toCache);
                 } catch (\Exception $e) {
                     die("Setting `$name` specifies a bad definition");
                 }
                 if($setting instanceof CobaltSetting === false) $setting = false;
             }
-            if(!$setting) $setting = new CobaltSetting($name, $this->normalizeSetting($name, $definition), $this->__user_modified_settings, $this->__settings);
+            if(!$setting) $setting = new CobaltSetting($name, $this->normalizeSetting($name, $definition), $this->__user_modified_settings, $this->__settings, $this, $toCache);
 
+            $this->instances[$name] = $setting;
             $toCache[$name] = $setting->get_value();
         }
 
+        $toCache = array_merge($toCache, $this->bootstrapManifestData());
+        
         // Get the ID of the cached settings
         $id = $this->__settings->_id;
         if(!$id) $this->__id();
+
         $this->updateOne(['_id' => $id],
         [
             '$set' => array_merge(
@@ -129,8 +138,7 @@ class Settings extends \Drivers\Database {
         ['upsert' => true]);
         $this->__settings = $this->fetchCachedSettings();
 
-        $this->bootstrapManifestData();
-        
+        return;
     }
 
     private function normalizeSetting($name, $data) {
@@ -147,6 +155,7 @@ class Settings extends \Drivers\Database {
 
     private function getMaxMTime() {
         $max_m_time = 0;
+        // $this->mtime_candidates = scandir(__ENV_ROOT__ . "/routes/");
         foreach ($this::__DEFINITIONS__ as $file) {
             $mtime = filemtime($file);
             if ($mtime === false) continue;
@@ -157,20 +166,20 @@ class Settings extends \Drivers\Database {
 
     public function getSettingDefinitions(){
         try {
-            $raw_decode = [];
+            $this->raw_decode = [];
             foreach($this::__DEFINITIONS__ as $file) {
                 if(!file_exists($file)) continue;
-                $raw_decode[$file] = jsonc_decode(file_get_contents($file), true, 512, JSON_ERROR_SYNTAX);
+                $this->raw_decode[$file] = jsonc_decode(file_get_contents($file), true, 512, JSON_ERROR_SYNTAX);
             }
 
             $values = [];
             $definitions = [];
-            foreach($raw_decode as $filename => $settings) {
+            foreach($this->raw_decode as $filename => $settings) {
                 $this->parseSetting($values, $definitions, $settings, $filename);
             }
             // $json = get_all_where_available($this::__DEFINITIONS__, true, true);
         } catch (\Exception $e) {
-            die($e);
+            die($e->getMessage());
         } 
         $this->default_values = $values;
         $this->definitions    = $definitions;
@@ -179,10 +188,9 @@ class Settings extends \Drivers\Database {
     private function parseSetting(&$values, &$def, $settings, $filename) {
         $detect_definition = ['default','directives','meta'];
         foreach($settings as $name => $data) {
-            $isDefinition = false;
+            $isDefinition = $this->isDefinition($data);
             if(gettype($data) == "array") {
-                $isDefinition = true;
-                if(array_intersect(array_keys($data), $detect_definition)) {
+                if($isDefinition) {
                     $data['defined'] = $filename;
                     $data['shorthand'] = false;
                     $def[$name] = array_merge($def[$name] ?? [], $data);
@@ -195,6 +203,19 @@ class Settings extends \Drivers\Database {
                 else $def[$name]['default'] = $data;
             }
         }
+    }
+
+    public function isDefinition($definition):bool {
+        $detect_definition = ['default', 'directives', 'meta', 'validate'];
+        // If it's not an array, it can't be a definition, return false
+        if(gettype($definition) !== "array") return false;
+        // intersect returns ['default'] <- is definition
+        // intersect returns [] <- is not a definition
+        // empty([]) // true, but it's NOT a definition
+        // empty(['default']) // false, but it IS a definition
+        // !empty() // to get the true status
+        return !empty(array_intersect(array_keys($definition), $detect_definition));
+
     }
         
     public function fetchCachedSettings() {
@@ -219,14 +240,180 @@ class Settings extends \Drivers\Database {
             'limit' => 1
         ]);
         $array = iterator_to_array($cursor);
-        if($array[0]) return iterator_to_array($array[0]);
-        return [];
+        if(!$array[0]) {
+            $this->insertOne([
+                'Meta' => [
+                    'type' => 'modified',
+                    'max_m_mtime' => time(),
+                ]
+            ]);
+            return $this->fetchModifiedSettings();
+        }
+        return iterator_to_array($array[0]);
     }
-
 
     public function bootstrapManifestData() {
-
+        // TODO: remove TIME_TO_UPDATE global
+        $GLOBALS['TIME_TO_UPDATE'] = true;
+        $final = [];
+        foreach($this::__MANIFESTS__ as $file) {
+            foreach(get_json($file) as $type => $data) {
+                $this->manifest_combine($type, $data, $final);
+            }
+        }
+        foreach($final as $type => $data) {
+            (!is_associative_array($data)) ? array_push($final[$type], ...$this->appendable[$type] ?? []) : $final[$type] = array_merge($final[$type], $this->appendable[$type]);
+        }
+        return $final;
     }
+
+    protected $appendable = [];
+
+    private function manifest_combine($name, $manifest, &$result) {
+        foreach($manifest as $type => $val) {
+            if($type === "common") continue;
+            if($type === "append") continue;
+            $index = "$name-$type";
+            if(!isset($result[$index])) $result[$index] = $manifest['common'] ?? [];
+            
+            $array_type = is_associative_array($manifest['common'] ?? $result[$index]);
+            
+            if($array_type) $result[$index] = array_merge($result[$index], $val ?? []);
+            else array_push($result[$index], ...$val);
+
+            if(isset($manifest['append'])) {
+                if(!isset($this->appendable[$index])) $this->appendable[$index] = [];
+                (!$array_type) ? array_push($this->appendable[$index], ...$manifest['append'] ?? []) : $this->appendable[$index] = array_merge($this->appendable[$index], $manifest['append'] ?? []);
+            }
+
+            array_unique($result[$index]);
+        }
+    }
+
+
+    /** Update functions */
+    public function update_setting($name, $value) {
+        $value = $this->validate($name, $value);
+        $isDefault = $this->is_default($name, $value);
+        $m_time = time();
+        $query = ['$set' => [$name => $value, "Meta.max_m_time" => $m_time]];
+        if($isDefault) $query = ['$unset' => [$name => true]];
+        $id = $this->__user_modified_settings['_id'];
+        
+        if(!$query['$set']) $query['$set'] = ["Meta.max_m_time" => $m_time];
+
+        $result = $this->updateOne(['_id' => $id], $query);
+        $this->bootstrap();
+        return [$name => $this->__settings[$name]];
+    }
+
+    public function push($name, $value) {
+        return $this->array_handler("push", $name, $value);
+    }
+
+    public function pull($name, $value) {
+        return $this->array_handler("pull", $name, $value);
+    }
+
+    public function array_handler($method, $name, $value) {
+        $value = $this->validate($name, $value);
+        if(gettype($this->__settings[$name]) !== "array") throw new \Exception("$name must be an array");
+        $m_time = time();
+        $method = match($method) {
+            'pull' => '$pull',
+            'push' => '$addToSet',
+        };
+        $query = [
+            $method => [$name => $value],
+            'Meta.max_m_time' => $m_time,
+        ];
+        $id = $this->__user_modified_settings['_id'];
+        $result = $this->updateOne(['_id' => $id], $query);
+        return [$name => $this->findOne(['_id' => $id])->{$name}];
+    }
+
+    public function reset_to_default($name) {
+        if(!$this->is_setting($name)) throw new \Exception("Setting is not defined.");
+        $query = ['$unset' => [$name => true]];
+
+        $id = $this->__user_modified_settings['_id'];
+
+        $result = $this->updateOne(['_id' => $id], $query);
+        return [$name => $this->update_settings[$name]->defaultValue];
+    }
+
+    private function is_setting($name) {
+        $this->bootstrap();
+        $this->update_settings = $this->instances;
+        return key_exists($name, $this->update_settings);
+    }
+
+    private function is_default($name, $value) {
+        return ($value === $this->update_settings[$name]->defaultValue);
+    }
+
+    function check_type($validation, $name, $value) {
+        $types = [
+            "boolean",
+            "integer",
+            "double",
+            "string",
+            "array",
+        ];
+
+        if(!in_array($validation['type'],$types)) throw new Exception("Invalid type specified for setting");
+        if(gettype($value) !== $validation['type']) throw new ValidationFailed("Invalid datatype");
+    }
+
+    function check_ctype($validation, $name, $value) {
+        $ctypes = [
+            'alnum' => 'ctype_alnum',
+            'alpha' => 'ctype_alpha',
+            'cntrl' => 'ctype_cntrl',
+            'digit' => 'ctype_digit',
+            'graph' => 'ctype_graph',
+            'lower' => 'ctype_lower',
+            'print' => 'ctype_print',
+            'punct' => 'ctype_punct',
+            'space' => 'ctype_space',
+            'upper' => 'ctype_upper',
+            'xdigit' => 'ctype_xdigit',
+        ];
+        if(!$ctypes[$validation['ctype']]($value)) throw new ValidationFailed("Ctype validation failed");
+    }
+
+    function filter($filters, $name, $value) {
+        if(gettype($filters) !== "array") $filters = [$filters => []];
+
+        $mutant = $value;
+        foreach($filters as $filter => $flags) {
+            $f = 0;
+            foreach($flags as $flag) {
+                $f &= constant($flag);
+            }
+            $f &= FILTER_NULL_ON_FAILURE;
+            $mutant = filter_var($mutant, constant($filter), $f);
+            if($mutant === null) throw new ValidationFailed("Filtering process failed.");
+        }
+
+        return $mutant;
+    }
+
+    private function validate($name, $value) {
+        if(!$this->is_setting($name, $value)) throw new ValidationIssue("Setting is not defined.");
+
+        $v = $this->instances[$name]->validate;
+
+        if(isset($v['confirm'])) confirm($v['confirm'], [$name => $value]);
+        if(isset($v['type'])) $this->check_type($v, $name, $value);
+        if(isset($v['ctype'])) $this->check_ctype($v, $name, $value);
+        
+        
+        if(isset(($v['filter']))) $value = $this->filter($v['filter'], $name, $value);
+
+        return $value;
+    }
+
 }
 
 

--- a/classes/Handlers/AdminHandler.php
+++ b/classes/Handlers/AdminHandler.php
@@ -36,46 +36,47 @@ class AdminHandler extends WebHandler {
 
     var $header_template = "/parts/admin-header.html";
     var $footer_template = "/parts/admin-footer.html";
+    var $meta_selector = "admin";
 
-    function generate_style_meta() {
-        $link_tags = "";
-        $compiled = "";
-        $debug = app("debug");
-        foreach (array_merge(app('common-css-packages'), app('admin-css-packages')) as $package) {
-            $files = files_exist([
-                __APP_ROOT__ . "/shared/css/$package",
-                __APP_ROOT__ . "/public/res/css/$package",
-                __ENV_ROOT__ . "/shared/css/$package"
-            ]);
-            if ($debug === true) {
-                $path = "/res/css/";
-                if (strpos($files[0], "/shared/css/")) $path = "/core-content/css/";
-                $link_tags .= "<link rel=\"stylesheet\" href=\"$path$package?{{app.version}}\">";
-            } else {
-                $compiled .= "\n\n" . file_get_contents($files[0]);
-            }
-        }
+    // function generate_style_meta() {
+    //     $link_tags = "";
+    //     $compiled = "";
+    //     $debug = app("debug");
+    //     foreach (array_merge(app('common-css-packages'), app('admin-css-packages')) as $package) {
+    //         $files = files_exist([
+    //             __APP_ROOT__ . "/shared/css/$package",
+    //             __APP_ROOT__ . "/public/res/css/$package",
+    //             __ENV_ROOT__ . "/shared/css/$package"
+    //         ]);
+    //         if ($debug === true) {
+    //             $path = "/res/css/";
+    //             if (strpos($files[0], "/shared/css/")) $path = "/core-content/css/";
+    //             $link_tags .= "<link rel=\"stylesheet\" href=\"$path$package?{{app.version}}\">";
+    //         } else {
+    //             $compiled .= "\n\n" . file_get_contents($files[0]);
+    //         }
+    //     }
 
-        foreach ($GLOBALS['PACKAGES']['css'] as $public => $private) {
-            $file = file_exists($private);
-            if (!$file) continue;
-            if ($debug === true) {
-                $link_tags .= "<link rel=\"stylesheet\" href=\"$public?{{app.version}}\">";
-            } else {
-                $compiled .= "\n\n" . file_get_contents($file);
-            }
-        }
-        if ($link_tags === "") $link_tags = "<link rel=\"stylesheet\" href=\"/core-content/css/admin.css?{{app.version}}\">";
+    //     foreach ($GLOBALS['PACKAGES']['css'] as $public => $private) {
+    //         $file = file_exists($private);
+    //         if (!$file) continue;
+    //         if ($debug === true) {
+    //             $link_tags .= "<link rel=\"stylesheet\" href=\"$public?{{app.version}}\">";
+    //         } else {
+    //             $compiled .= "\n\n" . file_get_contents($file);
+    //         }
+    //     }
+    //     if ($link_tags === "") $link_tags = "<link rel=\"stylesheet\" href=\"/core-content/css/admin.css?{{app.version}}\">";
 
-        if ($compiled !== "") {
-            $minifier = new \MatthiasMullie\Minify\CSS();
-            $minifier->add($compiled);
-            $compiled = $minifier->minify();
+    //     if ($compiled !== "") {
+    //         $minifier = new \MatthiasMullie\Minify\CSS();
+    //         $minifier->add($compiled);
+    //         $compiled = $minifier->minify();
 
-            $cache = new CacheManager("css-precomp/package.css");
-            $cache->set($compiled, false);
-        }
-        return $link_tags;
-    }
+    //         $cache = new CacheManager("css-precomp/package.css");
+    //         $cache->set($compiled, false);
+    //     }
+    //     return $link_tags;
+    // }
 
 }

--- a/classes/Plugins/Manager.php
+++ b/classes/Plugins/Manager.php
@@ -32,7 +32,7 @@ class Manager {
 
     function __construct() {
         // if (!file_exists($this->plugins_available)) $this->init_available_file();
-        // if ($GLOBALS['time_to_update']) 
+        // if ($GLOBALS['TIME_TO_UPDATE']) 
         $this->update_plugin_database();
         $this->directory = get_json($this->plugin_directory) ?? [];
         $this->enabled_names = array_unique(get_json($this->enabled_plugins));

--- a/classes/SettingsManager/SettingsManager.php
+++ b/classes/SettingsManager/SettingsManager.php
@@ -178,7 +178,7 @@ class SettingsManager {
         // Check if we need to import our settings from the cache
         $this->got_from_cache = $this->from_cache();
         if ($this->enable_settings_from_cache && $this->got_from_cache) { // Settings ARE available from the cache
-            $GLOBALS['time_to_update'] = false;
+            $GLOBALS['TIME_TO_UPDATE'] = false;
             // Load the cached settings file
             $settings = $this->cache_resource->get("json");
 
@@ -194,7 +194,7 @@ class SettingsManager {
             return $this;
         }
 
-        $GLOBALS['time_to_update'] = true;
+        $GLOBALS['TIME_TO_UPDATE'] = true;
         // Load all the settings files
         $this->load_settings();
         // Process the settings

--- a/classes/Validation/NormalizationHelpers.php
+++ b/classes/Validation/NormalizationHelpers.php
@@ -415,7 +415,7 @@ abstract class NormalizationHelpers {
         return $valid;
     }
 
-    function markdown_word_limit(string $markdown, int $word_limit = 350): string {
+    function markdown_word_limit(string|null $markdown, int $word_limit = 350): string {
         $mutant = $markdown;
 
         if(str_word_count($mutant, 0) > $word_limit) {

--- a/cli/cobalt.php
+++ b/cli/cobalt.php
@@ -2,7 +2,7 @@
 
 /** CHECK PHP VERSION */
 
-if( version_compare(phpversion(), '7.3.0', '<=') ) die("Your version of PHP must be version 7.4 or above.");
+if( version_compare(phpversion(), '8.1.0', '<=') ) die("Your version of PHP must be version 8.1 or above. Your version: " . phpversion());
 
 define('__CLI_ROOT__', __DIR__);
 

--- a/cli/commands/Settings.php
+++ b/cli/commands/Settings.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @todo Do not display help items that require environment context if in pre-env
+ */
+class Settings {
+
+    // public $help_documentation = [
+    //     'modified' => [
+    //         'description' => "List all settings that have been modified by the user",
+    //         'context_required' => true,
+    //     ],
+    //     'reset' => [
+    //         'description' => "[name] Reset the specified setting to default",
+    //         'context_required' => true
+    //     ],
+    //     'value' => [
+    //         'description' => "[name] Get the current value of a setting",
+    //         'context_required' => true
+    //     ],
+    //     'set' => [
+    //         'description' => "[name] [value] Update a setting",
+    //         'context_required' => true
+    //     ],
+    //     'push' => [
+    //         'description' => "[name] [value] Push a value to an array (no duplicates)",
+    //         'context_required' => true,
+    //     ],
+    //     'pull' => [
+    //         'description' => "[name] [value] Pull a value from an array",
+    //         'context_required' => true
+    //     ]
+    // ];
+
+    public function modified() {
+        
+        $t = new \Render\CLITable();
+        $t->head([
+            'name' => [
+                'title' => 'Name',
+            ],
+            'value' => [
+                'title' => 'Value'
+            ]
+        ]);
+        
+        foreach ($GLOBALS['app']->__settings as $setting) {
+            $t->row([
+                'name' => $setting->meta['name'],
+                'value' => $setting->value
+            ]);
+        }
+        $t->render();
+    }
+
+    public function reset($name) {
+        $GLOBALS['app']->reset_to_default($name);
+        return "Reset $name to default value";
+    }
+
+    public function set($name) {
+        $value = $this->value_parse();
+        $GLOBALS['app']->update_setting($name, $value);
+        return "Updated $name";
+    }
+
+    public function push($name, $value) {
+        $value = $this->value_parse();
+        return $GLOBALS['app']->push($name, $value);
+    }
+
+    public function pull($name, $value) {
+        $value = $this->value_parse();
+        return $GLOBALS['app']->pull($name, $value);
+    }
+
+    private function value_parse() {
+        $value = readline("> ");
+        if($value === "true") $value = true;
+        if($value === "false") $value = false;
+        if(ctype_digit($value)) $value = (int)$value;
+        return $value;
+    }
+}

--- a/config/default_permissions.jsonc
+++ b/config/default_permissions.jsonc
@@ -14,6 +14,13 @@
         "default": false,
         "ring": 1
     },
+    "Auth_modify_cobalt_settings": {
+        "group": "Admin",
+        "label": "Modify Cobalt settings.<help-span value='Access to the Cobalt Settings panel, able to modify them.'></help-span>",
+        "dangerous": true,
+        "default": false,
+        "ring": 1
+    },
     "Debug_access": {
         "group": "Admin",
         "label": "Access to debug tools for web developers.<help-span value='Most people do NOT need this.'></help-span>",

--- a/config/default_settings.jsonc
+++ b/config/default_settings.jsonc
@@ -27,6 +27,12 @@
             "group": "Basic",
             "name": "Domain Name",
             "type": "input"
+        },
+        "validate": {
+            "confirm": "If you change this value, you may lose access to this page and will need to manually change the value to regain access.",
+            "filter": {
+                "FILTER_VALIDATE_URL": []
+            }
         }
     },
     /* The full name of the application. */
@@ -63,21 +69,7 @@
             "type": "input"
         },
         "directives": {
-            "alias": "app_short_name"
-        }
-    },
-    /* The name of the designer as well as their website and title text */
-    "designer": {
-        "default": {
-            "prefix": "Designed by",
-            "name":   "Heavy Element, Inc.",
-            "href":   "https://heavyelement.io/",
-            "title":  "Maine's Premier New Media Production Studio"
-        },
-        "meta": {
-            "group": "Basic",
-            "name": "Designer Credit",
-            "type": "input-object"
+            "alias": "app_name"
         }
     },
     /* Debug routes include things like the WebComponent input tests */
@@ -88,6 +80,9 @@
             "name": "Enable debug routes",
             "type": "input-switch",
             "debug": true
+        },
+        "validate": {
+            "type": "boolean"
         }
     },
     /* I don't think this does anything yet -GM */
@@ -98,6 +93,9 @@
             "name": "Route Cache Disabled",
             "type": "input-switch",
             "debug": true
+        },
+        "validate": {
+            "type": "boolean"
         }
     },
     "cached_content_disabled": {
@@ -107,6 +105,9 @@
             "name": "Cached Content Disabled",
             "type": "input-switch",
             "debug": true
+        },
+        "validate": {
+            "type": "boolean"
         }
     },
     "settings_cache_disabled": {
@@ -116,6 +117,9 @@
             "name": "Settings Cahce Disabled",
             "type": "input-switch",
             "debug": true
+        },
+        "validate": {
+            "type": "boolean"
         }
     },
     /* Enabled the core-content/ route */
@@ -126,6 +130,9 @@
             "name": "Core Content Disabled",
             "type": "input-switch",
             "debug": true
+        },
+        "validate": {
+            "type": "boolean"
         }
     },
 
@@ -133,6 +140,7 @@
     email templates and more. */
     "fonts": {
         "default": [],
+        // "definiiton": "Fonts",
         "directives": {
             "merge":  {
                 "head": {
@@ -145,64 +153,35 @@
                 }
             },
             "style": true
-        },
-        "meta": {
-            "group": "Look &amp; Feel",
-            "name": "Default Fonts",
-            "type": "input-object"
         }
+        // "meta": {
+        //     "group": "Look &amp; Feel",
+        //     "name": "Default Fonts",
+        //     "view": "/admin/settings/inputs/fonts.html"
+        // }
     },
     "css-vars": {
         "default": [],
         "directives": {
             "merge": {
-                "modal-z-index": 2000,
-                "body-background": "#efefef",
-                "box-shadow": "0 4px 10px rgba(0, 0, 0, .2)",
-                "color-header-branding": "#004BA8",
-                "color-user-panel-button": "#342A21",
-                "color-admin-panel-background": "var(--project-color-header-branding)",
-                "color-admin-panel-font": "white",
-                "color-acknowledge": "#598B2C",
-                "color-active": "#598B2C",
-                "color-inactive": "#B1C1C0",
-                "color-input-border-nofocus": "#b1c3c3",
-                "color-input-border-focus": "#000",
-                "color-input-background": "#fff",
-                "color-input-text-color": "#000",
-                "color-input-background-focus": "#FFF",
-                "color-input-invalid-border": "#BB4430",
-                "color-input-invalid-bg": "#F7E2DE",
-                "color-input-invalid-label-text": "#FFF",
-                "color-input-disabled": "#F4F6F6",
-                "color-disabled": "rgba(0,0,0,.2)",
-                "color-table-border": "1px solid var(--project-color-input-border-nofocus)",
-                "color-table-bg-odd": "var(--project-color-input-background)",
-                "color-table-bg-even": "var(--project-color-input-disabled)",
-                "color-problem": "#FE5F55",
-                "color-button-init": "#004BA8",
-                "color-button-hover": "#9DD1F1",
-                "color-button-text": "#FFF",
-                "color-button-hover-text": "#000",
-                "color-button-pressed": "#00377A",
-                "calendar-borders": "1px solid var(--project-color-button-init)",
-                "calendar-cell-bg": "#FFF",
-                "calendar-cell-other-bg": "#EFEFEF",
-                "calendar-cell-txt": "#000",
-                "calendar-header-color": "var(--project-color-button-init)",
-                "calendar-header-text": "var(--project-color-button-text)",
-                "action-menu-background": "var(--project-color-input-disabled)",
-                "action-menu-border": "var(--project-color-table-border)",
-                "action-menu-hover": "var(--project-color-inactive)",
-            
-                "events-banner-background": "#efefef",
-                "events-banner-text": "#000000",
-                "events-button-color": "var(--project-color-button-init)",
-                "events-button-color-hover": "var(--project-color-button-hover)",
-                "events-button-text": "var(--project-color-button-text)",
-                "events-button-text-hover": "var(--project-color-button-hover-text)"
+                
             },
             "style": true
+        }
+    },
+
+    /* The name of the designer as well as their website and title text */
+    "designer": {
+        "default": {
+            "prefix": "Designed by",
+            "name":   "Heavy Element, Inc.",
+            "href":   "https://heavyelement.io/",
+            "title":  "Maine's Premier New Media Production Studio"
+        },
+        "meta": {
+            "group": "Look &amp; Feel",
+            "name": "Designer Credit",
+            "view": "/admin/settings/inputs/designer.html"
         }
     },
     
@@ -221,41 +200,23 @@
 
     "API_CORS_allowed_origins": {
         "default": [],
-        "meta": {
-            "group": "API",
-            "name": "Allowed Origins",
-            "type": "input-array"
-        },
+        // "meta": {
+        //     "group": "API",
+        //     "name": "Allowed Origins",
+        //     "type": "input-array"
+        // },
         "directives": {
             "push": [
                 "domain_name"
             ]
         }
     },
+    // This was once allowed to be modified by the user in the Settings panel
+    // but people could toggle it and then not be able to change it.
     "API_CORS_enable_other_origins": {
-        "default": true,
-        "meta": {
-            "group": "API",
-            "name": "Enable Other Origins",
-            "type": "input-switch"
-        }
+        "default": true
     },
-    "API_contact_form_enabled": {
-        "default": false,
-        "meta": {
-            "group": "API",
-            "name": "Enable Contact Form",
-            "type": "input-switch"
-        }
-    },
-    "API_contact_form_recipient": {
-        "default": "",
-        "meta": {
-            "group": "API",
-            "name": "Contact Form Recipient",
-            "type": "input"
-        }
-    },
+
     "CobaltEvents_enabled": {
         "default": true,
         "directives": {
@@ -263,8 +224,11 @@
         },
         "meta": {
             "group": "Banners &amp; Pop-ups",
-            "name": "Enable Banners &amp; Pop-ups",
+            "name": "Enable Event Banners <help-span value='Enables the Event Manager and allows you to schedule private & public pop-ups and banners.'></help-span>",
             "type": "input-switch"
+        },
+        "validate": {
+            "type": "boolean"
         }
     },
     "CobaltEvents_database_collection": {
@@ -280,6 +244,52 @@
         "default": "cobalt_http_error"
     },
     /** Mail **/
+
+    "API_contact_form_enabled": {
+        "default": false,
+        "meta": {
+            "group": "Mail",
+            "name": "Enable Contact Form",
+            "type": "input-switch"
+        },
+        "validate": {
+            "type": "boolean"
+        }
+    },
+    "API_contact_form_recipient": {
+        "default": "",
+        "meta": {
+            "group": "Mail",
+            "name": "Contact Form Recipient",
+            "type": "input"
+        }
+    },
+
+    "Mail_username": {
+        "default": "",
+        "directives": {
+            "env": "MAIL_USERNAME"
+        },
+        "meta": {
+            "group": "Mail",
+            "name": "SMTP Username",
+            "type": "input"
+        }
+    },
+
+    "Mail_password": {
+        "default": "",
+        "directives": {"env": "MAIL_PASSWORD"},
+        "meta": {
+            "group": "Mail",
+            "name": "SMTP Password",
+            "type": "input"
+        },
+        "validate": {
+            "confirm": "Are you sure you want to update this password? Doing so will overwrite your current password!"
+        }
+    },
+
     "Mail_smtp_host": {
         "default": "",
         "directives":{
@@ -291,6 +301,20 @@
             "type": "input"
         }
     },
+
+    "Mail_port": {
+        "default": 587,
+        "directives":{"env": "MAIL_PORT"},
+        "meta": {
+            "group": "Mail",
+            "name": "SMTP Port",
+            "type": "number"
+        },
+        "validate": {
+            "type": "int"
+        }
+    },
+    
     "Mail_smtp_auth": {
         "default": true,
         "directives": {"env": "MAIL_AUTH"},
@@ -298,22 +322,40 @@
             "group": "Mail",
             "name": "SMTP Auth Enabled",
             "type": "input-switch"
+        },
+        "validate": {
+            "type": "boolean"
         }
     },
-    "Mail_SMTP_options": {
-        "default": {}
-    },
-    "Mail_username": {
+
+    "Mail_reply_to_address": {
         "default": "",
-        "directives": {
-            "env": "MAIL_USERNAME"
-        },
+        "directives":{"alias": "Mail_from_address"},
         "meta": {
             "group": "Mail",
-            "name": "Username",
+            "name": "Reply To",
+            "type": "input"
+        },
+        "validate": {
+            "filter": {
+                "FILTER_VALIDATE_EMAIL": {}
+            }
+        }
+    },
+    "Mail_reply_to_name": {
+        "default": "",
+        "directives":{"alias": "app_short_name"},
+        "meta": {
+            "group": "Mail",
+            "name": "Reply To Name",
             "type": "input"
         }
     },
+    
+    "Mail_SMTP_options": {
+        "default": {}
+    },
+    
     "Mail_from_address": {
         "default": "",
         "directives":{"alias": "Mail_username"},
@@ -332,76 +374,63 @@
             "type": "input"
         }
     },
-    "Mail_reply_to_address": {
-        "default": "",
-        "directives":{"alias": "Mail_from_address"},
-        "meta": {
-            "group": "Mail",
-            "name": "Reply To",
-            "type": "input"
-        }
-    },
-    "Mail_reply_to_name": {
-        "default": "",
-        "directives":{"alias": "app_short_name"},
-        "meta": {
-            "group": "Mail",
-            "name": "Reply To Name",
-            "type": "input"
-        }
-    },
-    "Mail_password": {
-        "default": "",
-        "directives": {"env": "MAIL_PASSWORD"},
-        "meta": {
-            "group": "Mail",
-            "name": "Mail Password",
-            "type": "input"
-        }
-    },
-    "Mail_port": {
-        "default": 587,
-        "directives":{"env": "MAIL_PORT"},
-        "meta": {
-            "group": "Mail",
-            "name": "SMTP Port",
-            "type": "input"
-        }
-    },
+    
+    
+
+
+
     "Cookie_consent_prompt": {
         "default": false,
         "meta": {
             "group": "Banners &amp; Pop-ups",
             "name": "Cookie Consent Prompt",
             "type": "input-switch"
+        },
+        "validate": {
+            "type": "boolean"
         }
     },
 
     "Posts_enable_parallax": {
-        "default": true,
+        "default": false,
+        "directives":{
+            "public": true
+        },
         "meta": {
             "group": "Parallax",
             "name": "Enable Parallax for Blog Post Headline Images",
             "type": "input-switch"
+        },
+        "validate": {
+            "type": "boolean"
         }
     },
     "enable_default_parallax": {
         "default": true,
-        "directives":{"public": true},
+        "directives":{
+            "public": true
+        },
         "meta": {
             "group": "Parallax",
-            "name": "Enable Parallax",
+            "name": "Enable Parallax <help-span value='Allows you to specify [parallax-mode=\"\"] attributes on elements in your pages.'></help-span>",
             "type": "input-switch"
+        },
+        "validate": {
+            "type": "boolean"
         }
     },
     "Parallax_enable_debug": {
-        
         "default": false,
-        "directives":{"public": true},
+        "directives":{
+            "public": true
+        },
         "meta": {
             "group": "Parallax",
-            "name": "Enable Parallax Debug",
+            "name": "Enable Parallax Debug <help-span value='Allows the scroll manager to display debug output to help troubleshoot parallax issues.'></help-span>",
             "type": "input-switch"
+        },
+        "validate": {
+            "type": "boolean"
         }
     },
        /* If true, the settings will be cached after being processed and the cache 
@@ -438,7 +467,7 @@
                     "prefix": "/debug/",
                     "exception_mode": "web",
                     "mode": "text/html",
-                    "permission": "Debug_access",
+                    // "permission": "Debug_access",
                     "session_refresh": true,
                     "api_access": true,
                     "vars": {
@@ -594,7 +623,7 @@
         "default": true,
         "directives": {   
             "required": {
-                "Auth_user_accounts_enabled": true
+                "Auth_user_accounts_enabled": {"is": true}
             }
         }
     },
@@ -605,7 +634,7 @@
         "default": true,
         "directives": {   
             "required": {
-                "Auth_user_accounts_enabled": true
+                "Auth_user_accounts_enabled": {"is": true}
             }
         }
     },
@@ -613,7 +642,7 @@
         "default": true,
         "directives": {   
             "required": {
-                "Auth_user_accounts_enabled": true
+                "Auth_user_accounts_enabled": {"is": true}
             }
         }
     },
@@ -621,7 +650,7 @@
         "default": false,
         "directives": {   
             "required": {
-                "Auth_user_accounts_enabled": true
+                "Auth_user_accounts_enabled": {"is": true}
             }
         }
     },
@@ -629,7 +658,7 @@
         "default": "/login",
         "directives": {   
             "required": {
-                "Auth_user_accounts_enabled": true,
+                "Auth_user_accounts_enabled": {"is": true},
                 "on_fail_value": ""
             },
             "public": true
@@ -685,6 +714,10 @@
                 "public_post": "/posts/{id}",
                 "public_post_options": {}
             }
+        },
+        "meta": {
+            "group": "Features",
+            "view": "/admin/settings/inputs/posts.html"
         }
     },
     /* 
@@ -702,6 +735,9 @@
             "group": "Cache &amp; Debug",
             "name": "Debug status",
             "type": "input-switch"
+        },
+        "validate": {
+            "type": "boolean"
         }
     }
 }

--- a/controllers/APIManagement.php
+++ b/controllers/APIManagement.php
@@ -10,7 +10,7 @@ class APIManagement {
         $apis = $this->load_files();
         $index = "";
         foreach($apis as $name => $values) {
-            $index .= "<a href='/admin/api/$name' class='pretty-link'>$values[icon]<span>$values[name]</span></a>";
+            $index .= "<a href='$name' class='pretty-link'>$values[icon]<span>$values[name]</span></a>";
         }
         
         add_vars([

--- a/controllers/Debug.php
+++ b/controllers/Debug.php
@@ -30,6 +30,14 @@ class Debug extends \Controllers\Pages {
         $settings = $GLOBALS['app']->__settings;
         $stored = $GLOBALS['app']->fetchModifiedSettings();
         $definitions = $GLOBALS['app']->definitions;
+        // $definitions['js-web'] = [];
+        // $definitions['js-admin'] = [];
+        // $definitions['css-web'] = [];
+        // $definitions['css-admin'] = [];
+        // $definitions['vars-web'] = [];
+        // $definitions['vars-admin'] = [];
+        // $definitions['root-style'] = [];
+        $order = array_unique(array_merge(array_keys($definitions), array_keys((array)$settings)));
 
         $buttons = "";
         $pages = "";
@@ -43,15 +51,18 @@ class Debug extends \Controllers\Pages {
             'style' => 'S'
         ];
 
-        foreach($definitions as $setting => $data) {
+        foreach($order as $setting) {
+            $data = $definitions[$setting] ?? [];
             $cached_value = $settings[$setting];
             $directives = "";
             foreach($definitions[$setting]['directives'] ?? [] as $dir => $d) {
                 if(key_exists($dir, $directive_abbr)) $directives .= $directive_abbr[$dir] . ",";
             }
             $directives = substr($directives,0,-1);
-            $buttons .= "<a href='#$setting'>$setting<span class='directives'>$directives</span></a>";
             $filename = str_replace([__ENV_ROOT__, __APP_ROOT__],['__ENV__', '__APP__'],$data['defined']);
+            $source = "<span class='source env'>ENV</span>";
+            if(strpos($filename, "__APP__") === 0) $source = "<span class='source app'>APP</span>";
+            $buttons .= "<a href='#$setting'>$source<span class='fake-link'>$setting</span><span class='directives'>$directives</span></a>";
             $shorthand = $data['shorthand'];
             unset($definitions[$setting]['defined']);
             unset($definitions[$setting]['shorthand']);

--- a/env.php
+++ b/env.php
@@ -26,7 +26,7 @@ session_start();
 if (!version_compare(PHP_VERSION, "8.1", ">=")) die("You must be running PHP version 8.1.0 or greater");
 
 /* Cobalt Version Number */
-define("__COBALT_VERSION", "1.0");
+define("__COBALT_VERSION", "2.0");
 
 /* ENV_ROOT defines the root of the core files (the dir this file resides in) */
 define("__ENV_ROOT__", __DIR__);
@@ -72,13 +72,6 @@ $app_env = __APP_ROOT__ . "/private/app_env.php";
 if (file_exists($app_env)) require_once $app_env;
 
 
-/** We will now instantiate our database connection */
-// require_once __ENV_ROOT__ . "/globals/settings.php";
-
-
-/** @global TIME_TO_UPDATE determines if we need to rebuild our cached assets */
-$GLOBALS['time_to_update'] = false;
-
 try {
     // Load our ACTIVE plugins.
     require_once __ENV_ROOT__ . "/globals/plugins.php";
@@ -87,7 +80,7 @@ try {
 }
 
 try {
-    $application = new \Cobalt\Settings\Settings(true);
+    $application = new \Cobalt\Settings\Settings();
     /** @global $app How we set up and process our settings */
     $app = $application;
 } catch (Exception $e) {

--- a/globals/context.php
+++ b/globals/context.php
@@ -125,7 +125,8 @@ if($context_result !== null) {
 
     $global_benchmarks = "";
     if(app('debug') && isset($context_processor->encoding_mode) && $context_processor->encoding_mode === "text/html") {
-        $global_benchmarks = view("/debug/benchmarks.html",['results' => str_replace("\"","\\\"",json_encode($GLOBALS['BENCHMARK_RESULTS']))]);
+        if($GLOBALS['TIME_TO_UPDATE']) $global_benchmarks .= "<script>console.warn('Cobalt Engine Bootstrap Completed')</script>";
+        $global_benchmarks .= view("/debug/benchmarks.html",['results' => str_replace("\"","\\\"",json_encode($GLOBALS['BENCHMARK_RESULTS']))]);
         echo $global_benchmarks;
     }
     ob_flush();

--- a/globals/global_declarations.php
+++ b/globals/global_declarations.php
@@ -9,3 +9,7 @@ $ROUTE_LOOKUP_CACHE = [];
 
 $PUBLIC_SETTINGS = [];
 $ROOT_STYLE = "";
+
+
+/** @global TIME_TO_UPDATE determines if we need to rebuild our cached assets */
+$TIME_TO_UPDATE = false;

--- a/globals/global_functions.php
+++ b/globals/global_functions.php
@@ -491,7 +491,7 @@ function get_json($file_name, $array = true) {
         else return false;
     }
     $json = file_get_contents($file_name);
-    return json_decode($json, $array);
+    return jsonc_decode($json, $array);
 }
 
 /** Parse JSONC (commented JSON)
@@ -567,6 +567,7 @@ function associative_to_path(array $arr) {
 
 /**
  * Will determine if an array has string keys
+ * Will provide a false positive if indexes are non-linear
  * @param mixed $array 
  * @return bool 
  */

--- a/manifest.jsonc
+++ b/manifest.jsonc
@@ -31,13 +31,18 @@
             "AudioPlayer.js",
             "CobaltScrollManager.js"
         ],
-        "public": [
+        "web": [
 
         ],
-        "private": [
+        "admin": [
             "protected/Posts.js",
             "protected/UserPanel.js",
             "protected/UserManager.js"
+        ],
+        "append": [
+            "main.js",
+            "app.js",
+            "Router.js"
         ]
     },
     "css": {
@@ -55,6 +60,7 @@
             "action-menu.css",
             "status-message.css",
             "form-request.css",
+            "login-form.css",
             "posts.css",
             "flex-table.css",
             "cobalt-events.css",
@@ -64,18 +70,71 @@
             "webcomponents.css",
             "audio-player.css",
             "paginated-container.css",
-            "parallax.css"
+            "parallax.css",
+            "header.css"
         ],
-        "public": [
-            "header.css",
+        "web": [
             "main.css"
         ],
-        "private": [
-            "protected/admin.css",
-            "login-form.css"
+        "admin": [
+            "protected/admin.css"
         ],
-        "public-vars": {
+        "append": [
             
-        }
+        ]
+    },
+    "vars": {
+        "common": {
+            "modal-z-index": 2000,
+            "body-background": "#efefef",
+            "box-shadow": "0 4px 10px rgba(0, 0, 0, .2)",
+            "color-header-branding": "#004BA8",
+            "color-user-panel-button": "#342A21",
+            "color-acknowledge": "#598B2C",
+            "color-active": "#598B2C",
+            "color-inactive": "#B1C1C0",
+            "color-input-border-nofocus": "#b1c3c3",
+            "color-input-border-focus": "#000",
+            "color-input-background": "#fff",
+            "color-input-text-color": "#000",
+            "color-input-background-focus": "#FFF",
+            "color-input-invalid-border": "#BB4430",
+            "color-input-invalid-bg": "#F7E2DE",
+            "color-input-invalid-label-text": "#FFF",
+            "color-input-disabled": "#F4F6F6",
+            "color-disabled": "rgba(0,0,0,.2)",
+            "color-table-border": "1px solid var(--project-color-input-border-nofocus)",
+            "color-table-bg-odd": "var(--project-color-input-background)",
+            "color-table-bg-even": "var(--project-color-input-disabled)",
+            "color-problem": "#FE5F55",
+            "color-button-init": "#004BA8",
+            "color-button-hover": "#9DD1F1",
+            "color-button-text": "#FFF",
+            "color-button-hover-text": "#000",
+            "color-button-pressed": "#00377A",
+            "calendar-borders": "1px solid var(--project-color-button-init)",
+            "calendar-cell-bg": "#FFF",
+            "calendar-cell-other-bg": "#EFEFEF",
+            "calendar-cell-txt": "#000",
+            "calendar-header-color": "var(--project-color-button-init)",
+            "calendar-header-text": "var(--project-color-button-text)",
+            "action-menu-background": "var(--project-color-input-disabled)",
+            "action-menu-border": "var(--project-color-table-border)",
+            "action-menu-hover": "var(--project-color-inactive)",
+            "events-banner-background": "#efefef",
+            "events-banner-text": "#000000",
+            "events-button-color": "var(--project-color-button-init)",
+            "events-button-color-hover": "var(--project-color-button-hover)",
+            "events-button-text": "var(--project-color-button-text)",
+            "events-button-text-hover": "var(--project-color-button-hover-text)"
+        },
+        "web": {
+            
+        },
+        "admin": {
+            "color-admin-panel-background": "#004BA8",
+            "color-admin-panel-font": "white"
+        },
+        "append": {}
     }
 }

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -16,7 +16,8 @@ Route::get("/settings/application/","CoreSettingsPanel@settings_index",[
         'name' => 'App Settings',
         'icon' => "settings-outline"
     ],
-    'navigation' => ['admin_basic_panel']
+    'navigation' => ['admin_basic_panel'],
+    'permission' => "Auth_modify_cobalt_settings"
 ]);
 
 if (app('Auth_logins_enabled')) {
@@ -69,7 +70,7 @@ if (app('Plugin_enable_plugin_support')) {
 }
 
 // if (has_permission("API_manage_keys")) {
-Route::get("/settings/api-keys", "APIManagement@index",[
+Route::get("/settings/api-keys/", "APIManagement@index",[
     'permission' => 'API_manage_keys',
     'anchor' => [
         'name' => "API Keys",

--- a/routes/apiv1.php
+++ b/routes/apiv1.php
@@ -23,6 +23,14 @@ if (app('Auth_logins_enabled')) {
     Route::put("/user/{id}/password",   "UserAccounts@update_basics",   ['permission' => 'Auth_allow_editing_users']);
     Route::put("/user/password",        "UserAccounts@change_my_password", ['permission' => 'self']);
     Route::delete("/user/{id}/delete",   "UserAccounts@delete_user",   ['permission' => 'Auth_allow_deleting_users']);
+
+    Route::put("/settings/update/", "CoreSettingsPanel@update", [
+        'permission' => 'Auth_modify_cobalt_settings'
+    ]);
+
+    Route::put("/settings/default/{name}", "CoreSettingsPanel@reset_to_default", [
+        'permission' => 'Auth_modify_cobalt_settings'
+    ]);
 }
 
 if (app('Web_main_content_via_api')) {

--- a/shared/css/components/cobalt-carousel.css
+++ b/shared/css/components/cobalt-carousel.css
@@ -47,7 +47,13 @@ cobalt-carousel .cobalt-carousel--scroll-container > * {
     flex-grow: 0;
 }
 
+cobalt-carousel[sizing="crop"] .cobalt-carousel--scroll-container > * {
+    /* width: auto; */
+    object-fit: cover;
+}
+
 cobalt-carousel .cobalt-carousel--scroll-container :is(img, picture, video) {
+    height: min(var(--height) 80vh);
     height: var(--height);
 }
 

--- a/shared/css/components/tab-nav.css
+++ b/shared/css/components/tab-nav.css
@@ -1,4 +1,4 @@
-tab-nav {
+:is(tab-nav,chip-nav) {
     display:flex;
     flex-direction: column;
     width: 100%;
@@ -6,7 +6,7 @@ tab-nav {
     background: var(--project-color-table-bg-odd);
 }
 
-tab-nav nav {
+:is(tab-nav,chip-nav) nav {
     display:flex;
     justify-content: center;
     gap: .5em;
@@ -14,7 +14,7 @@ tab-nav nav {
     border-bottom: var(--project-color-table-border);
 }
 
-tab-nav nav a {
+:is(tab-nav,chip-nav) nav a {
     display:block;
     color: black;
     text-decoration: none;
@@ -26,14 +26,14 @@ tab-nav nav a {
     box-sizing: border-box;
 }
 
-tab-nav a[disabled="disabled"] {
+:is(tab-nav,chip-nav) a[disabled="disabled"] {
     background: inherit;
     color: var(--project-color-input-border-nofocus);
     font-style:italic;
     pointer-events: none;
 }
 
-tab-nav nav a.tab-nav--current-tab {
+:is(tab-nav,chip-nav) nav a.tab-nav--current-tab {
     color: inherit;
     /* border-bottom: 1px solid; */
     box-shadow: 0 2px 0 var(--project-color-table-bg-odd), 0 -2px;
@@ -41,14 +41,18 @@ tab-nav nav a.tab-nav--current-tab {
     font-style: normal;
 }
 
-tab-nav > *:not(nav) {
+:is(tab-nav,chip-nav) > *:not(nav) {
     display: none;
     /* visibility: none; */
     padding: .5rem .5rem .6rem;
 }
 
-tab-nav:not(.tab-nav--hydrated) > :target,
-tab-nav .tab-nav--current-content {
+:is(tab-nav,chip-nav):not(.tab-nav--hydrated) > :target,
+:is(tab-nav,chip-nav) .tab-nav--current-content {
     display: flex;
     visibility: visible;
+}
+
+chip-nav {
+    
 }

--- a/shared/css/header.css
+++ b/shared/css/header.css
@@ -150,22 +150,42 @@ header nav a.navigation--current {
   color: var(--project-color-button-text);
 }
 
-@media only screen and (max-width:900px) {
-  #nav-menu-spawn {
-    display: flex;
-  }
-  body > header {
-    width: 100vw;
-    height: 100vh;
-    transform: translateX(200%);
-    transition: transform .6s;
-    flex-direction: column;
-    position: fixed;
-  }
-  #nav-menu-spawn-nojs:checked+header {
-    transform: translateX(0);
-  }
-  .cobalt-events--default.cobalt-events--banner{
-      
-  }
+@media only screen and (max-width:35em) {
+    #nav-menu-spawn {
+        display: flex;
+    }
+    body > header {
+        width: 100vw;
+        height: 100vh;
+        transform: translateX(200%);
+        transition: transform .6s;
+        flex-direction: column;
+        position: fixed;
+    }
+    #nav-menu-spawn-nojs:checked+header {
+        transform: translateX(0);
+    }
+    .cobalt-events--default.cobalt-events--banner{
+        
+    }
+
+    header .directory--group li:has(ul) a {
+        padding:1rem;
+    }
+
+    header .directory--group li .directory--submenu,
+    header .directory--group li:hover .directory--submenu {
+        display:flex;
+        position: initial;
+        top: unset;
+        left: unset;
+        background: unset;
+        color: unset;
+        box-shadow: unset;
+    }
+
+    /* .directory--group .directory--submenu {
+        display: flex;
+    } */
+
 }

--- a/shared/css/inputs.css
+++ b/shared/css/inputs.css
@@ -507,10 +507,10 @@ progress-bar {
   display: block;
   position: relative;
   width: 100%;
-  height: 2rem;
+  height: 1rem;
   border: 1px solid var(--project-color-input-border-nofocus);
   background: var(--project-color-input-disabled);
-  border-radius: 4rem;
+  /* border-radius: 4rem; */
   overflow:hidden;
 }
 
@@ -521,18 +521,34 @@ progress-bar::before{
   position: absolute;
   top:0;
   left:0;
-  background-image: linear-gradient( -45deg, 
-    rgba(0, 0, 0, 0.2) 25%, 
-    transparent 25%, 
-    transparent 50%, 
-    rgba(0, 0, 0, 0.2) 50%, 
-    rgba(0, 0, 0, 0.2) 75%, 
-    transparent 75%,
-    transparent
+  background-image: linear-gradient(
+    90deg,
+    var(--project-body-background) 0%,
+    var(--project-color-input-border-nofocus) 40%,
+    var(--project-color-input-border-nofocus) 70%,
+    var(--project-body-background) 100%
   );
-  background-size: 50px 50px;
-  animation: progressBarbershopPole 5s linear infinite;
+  background-repeat: none;
+  background-color: var(--project-body-background);
+  background-size: 100% 100%;
+  animation: progressBarIdle 1s linear infinite;
   transition: height 600ms ease-out;
+}
+
+progress-bar.spa-loading-indicator {
+  border: none;
+  position: fixed;
+  top: -100%;
+  left: 0;
+  opacity: 0;
+  transition: top .5s, opacity .5s;
+  z-index: calc(var(--project-modal-z-index) * 100);
+  pointer-events: none;
+}
+
+progress-bar.spa-loading-indicator.navigation-start {
+  top: 0;
+  opacity: 1;
 }
 
 .form-request--processing progress-bar{
@@ -551,12 +567,12 @@ progress-bar .progress-bar--indicator{
   border-radius: 6px;
 }
 
-@keyframes progressBarbershopPole{
+@keyframes progressBarIdle{
   0% {
-    background-position: 0 0;
+    background-position: 0px 0px;
   }
   100% {
-    background-position: 50px 50px;
+    background-position: 100vw 0;
   }
 }
 

--- a/shared/css/posts.css
+++ b/shared/css/posts.css
@@ -193,4 +193,26 @@ article.cobalt-post + article.cobalt-post {
     article.cobalt-post .cobalt-post--header ul {
         flex-wrap:wrap;
     }
+    .cobalt-posts--public-index a.cobalt-post--blurb {
+        width:100%;
+        height: 50vh;
+    }
+    .cobalt-posts--public-index .cobalt-post--blurb.cobalt-post--prominent .cobalt-post--header {
+        margin-bottom: 1em;
+    }
+    .cobalt-posts--public-index .cobalt-post--blurb.cobalt-post--prominent {
+        height: 50vh;
+        display: flex;
+        flex-direction: column;
+    }
+    .cobalt-posts--public-index .cobalt-post--blurb.cobalt-post--prominent .cobalt-post--splash{
+        width: 100%;
+        flex-grow:1;
+        min-height: 30vh;
+    }
+    .cobalt-posts--public-index .cobalt-post--blurb ul {
+        display: flex;
+        flex-direction: column;
+        gap: unset;
+    }
 }

--- a/shared/css/status-message.css
+++ b/shared/css/status-message.css
@@ -47,7 +47,7 @@ message-item{
         align-items: center;
     }
     
-    message-item article{
+    message-item section{
         padding: calc(var(--margins) / 2) 0;
         height: var(--height);
         flex-grow: 1;
@@ -122,8 +122,16 @@ message-item{
 
 @keyframes status-message--update {
     from {
-        transform: scale(1.2);
+        transform: scale(1.1);
     }
 }
 
 /* status-item */
+
+@media only screen and (max-width: 35em) {
+    message-container {
+        width:100vw;
+        margin: 0;
+    }
+    
+}

--- a/src/CobaltScrollManager.js
+++ b/src/CobaltScrollManager.js
@@ -31,17 +31,18 @@ class CobaltScrollManager {
         this.parallaxElements = []; // The elements to be updated
         this.modifier = modifier;
 
-        this.debug = app("Parallax_enable_debug");
+        this.debug = app("Parallax_enable_debug") ?? false;
 
         document.addEventListener("navigationEvent", this.selectElements.bind(this));
         document.addEventListener("scrollManagerUpdate", this.selectElements.bind(this));
 
-        window.addEventListener("resize", () => {
-            // console.log("resize");
+        if(app("enable_default_parallax")) window.addEventListener("resize", () => {
             this.selectElements();
         });
 
         this.initDebug();
+
+        if(app("enable_default_parallax")) this.selectElements();
     }
 
     async selectElements() {

--- a/src/InputComponents.js
+++ b/src/InputComponents.js
@@ -796,16 +796,18 @@ class ProgressBar extends HTMLElement {
         super();
         this.maxValue = this.getAttribute("max") || 100;
         this.progressValue = 0;
-        this.messageContainer = document.createElement("div");
-        this.messageContainer.innerHTML = "&nbsp;";
     }
 
     connectedCallback() {
+        if(this.getAttribute("no-message") === null) {
+            this.messageContainer = document.createElement("div");
+            this.messageContainer.innerHTML = "&nbsp;";
+        }
         this.bar = document.createElement("div");
         this.bar.classList.add("progress-bar--indicator");
         this.appendChild(this.bar);
         this.dimensions = get_offset(this);
-        this.parentNode.insertBefore(this.messageContainer, this.nextSibling);
+        if(this.messageContainer) this.parentNode.insertBefore(this.messageContainer, this.nextSibling);
     }
 
     /**

--- a/src/StatusMessage.js
+++ b/src/StatusMessage.js
@@ -6,15 +6,17 @@ class StatusMessage {
         this.action = action;
         this.closeable = close;
         this.type = type;
+
+        // Let's now set this message up to be added to the MessageHandler class
         this.element = window.messageHandler.message(this);
     }
 
     /** @todo add action event updating */
     async update(message, icon = this.icon, action = this.action) {
-        const article = this.element.querySelector("article");
+        const section = this.element.querySelector("section");
         const ionIcon = this.element.querySelector("ion-icon");
         const animClass = "status-message--update";
-        article.innerHTML = message;
+        section.innerHTML = message;
         ionIcon.name = icon;
         await wait_for_animation(this.element, animClass);
         this.element.classList.remove(animClass);
@@ -42,7 +44,7 @@ class MessageHandler {
         const message = document.createElement("message-item");
         message.classList.add(`status-message--${details.type}`);
         message.setAttribute("data-id",details.id);
-        message.innerHTML = `<ion-icon name='${details.icon}'></ion-icon><article>${details.message}</article>`;
+        message.innerHTML = `<ion-icon name='${details.icon}'></ion-icon><section>${details.message}</section>`;
         let close_btn = document.createElement("button");
         close_btn.innerHTML = window.closeGlyph;
         // close_btn.addEventListener()
@@ -55,9 +57,16 @@ class MessageHandler {
         });
 
         if(details.id in this.messageQueue) {
-            return details.update({message: details.id});
+            return this.messageQueue[details.id].update(
+                details.message || this.messageQueue[details.id].message || "",
+                details.icon || this.messageQueue[details.id].icon || "",
+                details.action || this.messageQueue[details.id].action || function () {return true},
+            );
         }
-        this.messageQueue[details.id] = message;
+
+        details.container = message;
+
+        this.messageQueue[details.id] = details;
         this.container.appendChild(message);
 
         this.spawn(message);
@@ -68,8 +77,8 @@ class MessageHandler {
     }
 
     async dismiss(details, event, withAction = true) {
-        let element = this.messageQueue[details.id];
-        if (!element) return;
+        let element = this.messageQueue[details.id].container || event.target.closest("message-item") || null;
+        if (!element) return console.warn("Could not find status message to close");
         try {
             if (withAction) await details.action(event, details);
         } catch (error) {
@@ -99,6 +108,13 @@ class MessageHandler {
     async no(element) {
         await wait_for_animation(element, "status-message--no");
         element.classList.remove("status-message--no");
+    }
+
+    async closeAll() {
+        for(const i in this.messageQueue) {
+            const message = this.messageQueue[i];
+            message.close();
+        }
     }
 }
 

--- a/src/components/tab-nav.js
+++ b/src/components/tab-nav.js
@@ -24,12 +24,16 @@
         
         this.nav.querySelectorAll("a").forEach(e => {
             const url = new URL(e.href).hash;
-            if(!url) console.warn("URL is missing a hash location", e);
+            if(!url) {
+                console.warn("URL is missing a hash location", e);
+                e.setAttribute("disabled","disabled");
+                return;
+            }
             const content = this.querySelector(url);
             if(!content) e.setAttribute("disabled","disabled");
             e.addEventListener("click", evt => {
                 // evt.preventDefault();
-                evt.stopPropagation();
+                // evt.stopPropagation();
                 // history.replaceState({},'',e.href);
                 // this.hashUpdate();
             });
@@ -45,7 +49,6 @@
         newHash = newHash;
 
         const anchors = this.nav.querySelectorAll("a");
-
         anchors.forEach(e => {
             e.classList.remove(this.currentNavClass);
         });
@@ -64,3 +67,9 @@
 }
 
 customElements.define("tab-nav", TabNav);
+
+class ChipNav extends TabNav {
+
+}
+
+customElements.define("chip-nav", ChipNav);

--- a/src/global_functions.js
+++ b/src/global_functions.js
@@ -299,7 +299,9 @@ function string_to_bool(str, altName = true) {
  * @returns bool
  */
 function compare_arrays(arr1, arr2, sort = false) {
-    if(sort)
+    // if(sort) {
+        
+    // }
     return JSON.stringify(arr1) === JSON.stringify(arr2);
 }
 

--- a/templates/admin/api/key.html
+++ b/templates/admin/api/key.html
@@ -1,29 +1,28 @@
+<h1>{{title}}</h1>
 
 <form-request method="PUT" action="/api/v1/api/key/{{id}}">
     <fieldset>
-        <label>Key</label>
+        <legend>Key Data</legend>
+        <label>Key <help-span value=""></help-span></label>
         <input type="string" name="key" value="{{token.key}}">
-    </fieldset>
-    <fieldset>
+    
         <label>Secret</label>
         <input type="password" name="secret" value="{{token.secret}}">
-    </fieldset>
-    <fieldset>
+    
         <label>Token</label>
         <input type="password" name="token" value="{{token.token}}">
     </fieldset>
     <fieldset>
+        <legend>Metadata</legend>
         <label>Type</label>
         <input-autocomplete value="{{token.type}}" name="type">
             <option value="Authorization">Authorization</option>
             <option value="Parameter">Parameter</option>
         </input-autocomplete>
-    </fieldset>
-    <fieldset>
+    
         <label>Prefix: {{token.prefix}}</label>
         <input type="string" name="prefix" value="{{token.prefix}}">
-    </fieldset>
-    <fieldset>
+    
         <label>Expiration</label>
         <input type="date" name="expiration" value="{{token.expiration}}">
     </fieldset>

--- a/templates/admin/settings/basic-settings.html
+++ b/templates/admin/settings/basic-settings.html
@@ -5,7 +5,6 @@
     </nav>
     {{!settings}}
 </tab-nav>
-<cite>Note: This page is just a placeholder for now</cite>
 
 <style>
     .list-panel {

--- a/templates/admin/settings/inputs/array.html
+++ b/templates/admin/settings/inputs/array.html
@@ -1,0 +1,5 @@
+<li>
+    <label>{{!name}}</label>
+    <input-array name='{{setting}}' {{disabled}}>{{!options}}</input-array>
+    @view("/admin/settings/inputs/reset.html");
+</li>

--- a/templates/admin/settings/inputs/bool.html
+++ b/templates/admin/settings/inputs/bool.html
@@ -1,0 +1,5 @@
+<li>
+    <label>{{!name}}</label>
+    <input-switch name='{{setting}}' checked='{{value}}' {{disabled}}></input-switch>
+    @view("/admin/settings/inputs/reset.html");
+</li>

--- a/templates/admin/settings/inputs/designer.html
+++ b/templates/admin/settings/inputs/designer.html
@@ -1,0 +1,27 @@
+<li>
+    <fieldset>
+        <legend>Designer Credit</legend>
+        <div class="hbox">
+            <label>
+                Credit Type
+            </label>
+            <input name="designer.prefix" value="{{value.prefix}}" placeholder="Credit Type">
+            <async-button method="PUT" action="/api/v1/settings/default/designer.prefix"></async-button>
+        </div>
+        <div class="hbox">
+            <label>
+                Designer Name
+            </label>
+            <input name="designer.name" value="{{value.name}}" placeholder="Designer Name">
+            <async-button method="PUT" action="/api/v1/settings/default/designer.name"></async-button>
+        </div>
+        <label>
+            Designer Website
+        </label>
+        <input name="designer.href" value="{{value.href}}" placeholder="Designer Website">
+        <label>
+            Link Title
+        </label>
+        <input name="designer.title" value="{{value.title}}" placeholder="Link Title">
+    </fieldset>
+</li>

--- a/templates/admin/settings/inputs/fonts.html
+++ b/templates/admin/settings/inputs/fonts.html
@@ -1,0 +1,7 @@
+<li>
+    <input-object-array value="{{$value}}">
+        <template>
+            
+        </template>
+    </input-object-array>
+</li>

--- a/templates/admin/settings/inputs/input.html
+++ b/templates/admin/settings/inputs/input.html
@@ -1,0 +1,5 @@
+<li>
+    <label>{{!name}}</label>
+    <input type='{{type}}' name='{{setting}}' value='{{value}}' {{disabled}}>
+    @view("/admin/settings/inputs/reset.html");
+</li>

--- a/templates/admin/settings/inputs/password.html
+++ b/templates/admin/settings/inputs/password.html
@@ -1,0 +1,5 @@
+<li>
+    <label>{{!name}}</label>
+    <input type='password' name='{{setting}}' {{disabled}}>
+    @view("/admin/settings/inputs/reset.html");
+</li>

--- a/templates/admin/settings/inputs/posts.html
+++ b/templates/admin/settings/inputs/posts.html
@@ -1,0 +1,10 @@
+<li>
+    <label>
+        Enable Blog Post system
+    </label>
+    <input-switch name="Posts.default_enabled" checked="{{value.default_enabled}}"></input-switch>
+</li>
+<li>
+    <label>Post link name</label>
+    <input name="Posts.default_name" value="{{value.default_name}}">
+</li>

--- a/templates/admin/settings/inputs/reset.html
+++ b/templates/admin/settings/inputs/reset.html
@@ -1,0 +1,1 @@
+<async-button method="PUT" action="/api/v1/settings/default/{{setting}}"><ion-icon name="refresh-circle"></ion-icon></async-button>

--- a/templates/debug/settings/container.html
+++ b/templates/debug/settings/container.html
@@ -15,9 +15,23 @@
     }
     #list a {
         display: flex;
+        text-decoration: none;
+        color:blue;
     }
-    #list a span {
+    #list a:nth-of-type(odd) {
+        background-color: var(--project-calendar-cell-other-bg)
+    }
+    #list a span.directives {
         margin-left: auto;
+    }
+    #list .source {
+        background-color:black;
+        color: white;
+        font-size: .7rem;
+        padding: .15rem;
+        margin: .1rem;
+        display:inline-grid;
+        place-items: center;
     }
     #list li {
         display: block;


### PR DESCRIPTION
Overhauled settings manager so users can modify settings in the /admin panel
Moved JS/CSS file declarations to manifest.jsonc
Incremented cobalt engine version number as a breaking change
WebHandler and AdminHandler now use $meta_selector property to pick which manifest list they use.
Made markdown_word_limit tolerate null
Increased PHP version requirement to 8.1.0 or greater
Added new permission "Auth_modify_cobalt_settings"
Overhauled setting declaration format
Added simple benchmarking system to PHP backend.
Fixed issue with mobile versions nested directory listings
Changed how progress-bars look
Added navigation progress-bar
Added responsive styling for posts
Added responsive styling for status-messages
Started working on chip-nav element
Added dummy admin.css file
Made API fetch requests abortable by calling ApiObject.abort()
Fixed issue where status messages with identical ids would not update properly.